### PR TITLE
how to log unapproved package and function use

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -87,7 +87,7 @@ get_file_path <- function(file = NA, normalize = TRUE){
 #' get_session_info()
 #'
 get_session_info <- function(){
-   return(capture.output(session_info(info = c("platform", "packages", "external"))))
+   return(capture.output(session_info(info = "all")))
 }
 
 

--- a/vignettes/approved.Rmd
+++ b/vignettes/approved.Rmd
@@ -19,7 +19,7 @@ library(timber)
 ## 1. Create a named list containing the functions approved for use for each package. If all functions for a package are approved for use, list "All".
 
 ```{r}
-approved_pkgs <- list(haven = "read_sas",
+approved_pkgs <- list(base = "mean",
                       dplyr = "All")
 approved_pkgs
 ```
@@ -100,9 +100,9 @@ close(fileConn)
 axecute(file.path(dir,"mpg.R"))
 ```
 
-Here we have the log. If you scroll to the "Unapproved Package and Functions" section, we will see we used `library()` and `mean()` from `package:base` and `pivot_wider` from `package:tidyr`.  We did not include any base or tidyr functions in our approved list, so this has been logged!
+Here we have the log. If you scroll to the "Unapproved Package and Functions" section, we will see we used `library()` from `package:base` and `pivot_wider` from `package:tidyr`.  We did not include any base or tidyr functions in our approved list, so this has been logged!
 
-|  {package:base} library, mean
+|  {package:base} library
 |  {package:tidyr} pivot_wider
 
 ```{r echo = FALSE}

--- a/vignettes/approved.Rmd
+++ b/vignettes/approved.Rmd
@@ -1,0 +1,114 @@
+---
+title: "Logging Unapproved Package and Function Use"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{approved}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+
+library(timber)
+```
+
+## 1. Create a named list containing the functions approved for use for each package. If all functions for a package are approved for use, list "All".
+
+```{r}
+approved_pkgs <- list(haven = "read_sas",
+                      dplyr = "All")
+approved_pkgs
+```
+
+## 2. Pass the named list through `build_approved()` to build your tibble.
+
+```{r}
+build_approved <- function(.x, .y){
+   
+  all <- tibble::tibble(function_name = getNamespaceExports(.x),
+                        library = paste0("package:", .x))
+
+  if (.y[1] %in% c("All", "all")){
+    all
+  } else{
+    all[all$function_name %in% .y,]
+  }
+  
+}
+
+approved <- purrr::map2_df(names(approved_pkgs), approved_pkgs, build_approved)
+
+approved
+
+```
+
+## 3. Save as `approved.rds` wherever you like.
+
+```{r}
+dir <- tempdir()
+saveRDS(approved, file.path(dir, "approved.rds"))
+```
+
+## 4. Update the `timber.approved` option to point to your `approved.rds` location. We recommend setting this in your `.Rprofile`.
+
+```{r}
+options(timber.approved = file.path(dir, "approved.rds"))
+```
+
+## 5. `timber` will take it from there. When each program is executed, packages and functions will be compared to `approved.rds` and if any unapproved use is found, it will be logged within the "Unapproved Package and Functions" section.
+
+## Example
+
+Let's write a simple script summarizing mean mpg from mtcars. We save this as `mpg.R` in the temporary directory `dir` and `axecute()` it.
+
+```{r}
+library(dplyr)
+
+results <- mtcars %>%
+   group_by(cyl) %>%
+   summarize(mean = mean(mpg)) %>%
+   mutate(label = "Mean MPG")
+
+results %>%
+   tidyr::pivot_wider(names_from = cyl, values_from = mean, id_cols = label)
+```
+
+```{r echo = FALSE}
+# write this to the temp directory so we have a script to axecute
+
+text <- 'library(dplyr)
+
+results <- mtcars %>%
+   group_by(cyl) %>%
+   summarize(mean = mean(mpg)) %>%
+   mutate(label = "Mean MPG")
+
+results %>%
+   tidyr::pivot_wider(names_from = cyl, values_from = mean, id_cols = label)'
+   
+fileConn <- file(file.path(dir,"mpg.R"))
+writeLines(text, fileConn)
+close(fileConn)
+
+```
+
+```{r results='hide'}
+axecute(file.path(dir,"mpg.R"))
+```
+
+Here we have the log. If you scroll to the "Unapproved Package and Functions" section, we will see we used `library()` and `mean()` from `package:base` and `pivot_wider` from `package:tidyr`.  We did not include any base or tidyr functions in our approved list, so this has been logged!
+
+|  {package:base} library, mean
+|  {package:tidyr} pivot_wider
+
+```{r echo = FALSE}
+cat(readLines(file.path(dir, "mpg.log")), sep = '\n')
+```
+
+```{r cleanup, echo = FALSE}
+unlink(dir, recursive = TRUE)
+```

--- a/vignettes/approved.Rmd
+++ b/vignettes/approved.Rmd
@@ -16,15 +16,16 @@ knitr::opts_chunk$set(
 library(timber)
 ```
 
-## 1. Create a named list containing the functions approved for use for each package. If all functions for a package are approved for use, list "All".
+## 1. Create a named list
+#### The named list contains the functions approved for use for each package. If all functions for a package are approved for use, list "All".
 
 ```{r}
 approved_pkgs <- list(base = "mean",
                       dplyr = "All")
 approved_pkgs
 ```
-
-## 2. Pass the named list through `build_approved()` to build your tibble.
+## 2. Build `approved.rds`
+#### Pass the named list through `build_approved()` to build your tibble.
 
 ```{r}
 build_approved <- function(.x, .y){
@@ -45,21 +46,23 @@ approved <- purrr::map2_df(names(approved_pkgs), approved_pkgs, build_approved)
 approved
 
 ```
-
-## 3. Save as `approved.rds` wherever you like.
+## 3. Save as `approved.rds`
+####  You can save this wherever you like.
 
 ```{r}
 dir <- tempdir()
 saveRDS(approved, file.path(dir, "approved.rds"))
 ```
 
-## 4. Update the `timber.approved` option to point to your `approved.rds` location. We recommend setting this in your `.Rprofile`.
+## 4. Update the `timber.approved` option
+### Update the `timber.approved` option to point to your `approved.rds` location. We recommend setting this in your `.Rprofile`.
 
 ```{r}
 options(timber.approved = file.path(dir, "approved.rds"))
 ```
 
-## 5. `timber` will take it from there. When each program is executed, packages and functions will be compared to `approved.rds` and if any unapproved use is found, it will be logged within the "Unapproved Package and Functions" section.
+## 5. You're done. Let's axecute! 
+#### `timber` will take it from there. When each program is executed, packages and functions will be compared to `approved.rds` and if any unapproved use is found, it will be logged within the "Unapproved Package and Functions" section.
 
 ## Example
 
@@ -97,18 +100,26 @@ close(fileConn)
 ```
 
 ```{r results='hide'}
-axecute(file.path(dir,"mpg.R"))
+axecute(file.path(dir,"mpg.R"), remove_log_object = FALSE)
 ```
 
-Here we have the log. If you scroll to the "Unapproved Package and Functions" section, we will see we used `library()` from `package:base` and `pivot_wider` from `package:tidyr`.  We did not include any base or tidyr functions in our approved list, so this has been logged!
+Here we have the log elements for "Used Package and Functions" and "Unapproved Package and Functions". We can see we used `library()` from `package:base` and `pivot_wider` from `package:tidyr`.  We did not include the base library or tidyr functions in our approved list, so this has been logged!
 
-|  {package:base} library
-|  {package:tidyr} pivot_wider
+```{r echo=FALSE}
+cleaned_log_vec <- c()
 
-```{r echo = FALSE}
-cat(readLines(file.path(dir, "mpg.log")), sep = '\n')
+cleaned_log_vec <- c(cleaned_log_vec,
+                           write_log_header("Used Package and Functions"),
+                           write_used_functions())
+
+cleaned_log_vec <- c(cleaned_log_vec,
+                           write_log_header("Unapproved Package and Functions"),
+                           write_unapproved_functions())
+cat(cleaned_log_vec, sep = "\n")
 ```
 
 ```{r cleanup, echo = FALSE}
+timber::log_remove()
+
 unlink(dir, recursive = TRUE)
 ```


### PR DESCRIPTION
I created a basic vignette to explain how to use timber to log the unapproved use along with a simple example.  I'm happy for this to go somewhere other than a vignette too.  Regardless, the content is here though and ready for review.

There is one function embedded in the vignette that we might want to export.  @kodesiba You mentioned maybe storing in some sort of utils.  Check out the vignette for more context for .x and .y arguments.

```r
build_approved <- function(.x, .y){
   
  all <- tibble::tibble(function_name = getNamespaceExports(.x),
                        library = paste0("package:", .x))

  if (.y[1] %in% c("All", "all")){
    all
  } else{
    all[all$function_name %in% .y,]
  }
  
}
```

I also don't want this to hold up anything, so if this isn't key, we can save for later.